### PR TITLE
Birthday reminders: notify at 7, 3, 1, and 0 days; add scheduler & channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release build
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "11"
+          cache: gradle
+
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+
+      - name: Upload release APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-apk
+          path: app/build/outputs/apk/release/app-release.apk
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.run_number }}
+          name: Release v${{ github.run_number }}
+          files: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "11"
+          java-version: "17"
           cache: gradle
 
       - name: Build release APK

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,38 +1,43 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
     namespace "com.osori.lovesj"
-    compileSdkVersion 33
+    compileSdk 34
+
     defaultConfig {
         applicationId "com.osori.lovesj"
-        minSdkVersion 27
-        targetSdkVersion 33
+        minSdk 27
+        targetSdk 34
         versionCode 2
         versionName "2.0.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
-        sourceCompatibility = '11'
-        targetCompatibility = '11'
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-//    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.2'
-    implementation 'de.hdodenhof:circleimageview:2.0.0'
-    implementation 'com.github.flavienlaurent.discrollview:library:0.0.2@aar'
-    testImplementation 'junit:junit:4.12'
-    testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation group: 'com.ibm.icu', name: 'icu4j', version: '4.8.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'de.hdodenhof:circleimageview:3.1.0'
+    implementation 'com.ibm.icu:icu4j:74.2'
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
+
+    androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,14 @@ android {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'org.jetbrains.kotlin:kotlin-stdlib:1.8.22'
+        force 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22'
+        force 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22'
+    }
+}
+
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 		  package="com.osori.lovesj">
 
+	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
 	<application
 			android:allowBackup="true"
 			android:icon="@mipmap/ic_launcher"
@@ -16,6 +19,18 @@
 				<category android:name="android.intent.category.LAUNCHER"/>
 			</intent-filter>
 		</activity>
+
+		<receiver
+				android:name=".notification.BirthdayAlarmReceiver"
+				android:exported="false"/>
+
+		<receiver
+				android:name=".notification.BirthdayBootReceiver"
+				android:exported="false">
+			<intent-filter>
+				<action android:name="android.intent.action.BOOT_COMPLETED"/>
+			</intent-filter>
+		</receiver>
 	</application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-		  package="com.osori.lovesj">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/java/com/osori/lovesj/activity/OsoriActivity.java
+++ b/app/src/main/java/com/osori/lovesj/activity/OsoriActivity.java
@@ -1,19 +1,31 @@
 package com.osori.lovesj.activity;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.viewpager.widget.ViewPager;
 
 import com.osori.lovesj.R;
 import com.osori.lovesj.listener.SwipeAdapter;
+import com.osori.lovesj.notification.BirthdayNotificationChannel;
+import com.osori.lovesj.notification.BirthdayNotificationScheduler;
 
 public class OsoriActivity extends AppCompatActivity {
+	private static final int POST_NOTIFICATION_REQUEST_CODE = 3001;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_osori);
+
+		BirthdayNotificationChannel.ensureCreated(this);
+		requestNotificationPermissionIfNeeded();
+		BirthdayNotificationScheduler.scheduleDaily(this);
 
         ViewPager viewPager = findViewById(R.id.view_page);
         viewPager.setOffscreenPageLimit(1);
@@ -21,4 +33,20 @@ public class OsoriActivity extends AppCompatActivity {
         viewPager.setAdapter(swipeAdapter);
         viewPager.setCurrentItem(1);
     }
+
+	private void requestNotificationPermissionIfNeeded() {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+			return;
+		}
+
+		if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+				== PackageManager.PERMISSION_GRANTED) {
+			return;
+		}
+
+		ActivityCompat.requestPermissions(
+				this,
+				new String[]{Manifest.permission.POST_NOTIFICATIONS},
+				POST_NOTIFICATION_REQUEST_CODE);
+	}
 }

--- a/app/src/main/java/com/osori/lovesj/notification/BirthdayAlarmReceiver.java
+++ b/app/src/main/java/com/osori/lovesj/notification/BirthdayAlarmReceiver.java
@@ -1,0 +1,12 @@
+package com.osori.lovesj.notification;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class BirthdayAlarmReceiver extends BroadcastReceiver {
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		BirthdayNotifier.notifyUpcomingBirthdays(context);
+	}
+}

--- a/app/src/main/java/com/osori/lovesj/notification/BirthdayBootReceiver.java
+++ b/app/src/main/java/com/osori/lovesj/notification/BirthdayBootReceiver.java
@@ -1,0 +1,14 @@
+package com.osori.lovesj.notification;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class BirthdayBootReceiver extends BroadcastReceiver {
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+			BirthdayNotificationScheduler.scheduleDaily(context);
+		}
+	}
+}

--- a/app/src/main/java/com/osori/lovesj/notification/BirthdayNotificationChannel.java
+++ b/app/src/main/java/com/osori/lovesj/notification/BirthdayNotificationChannel.java
@@ -1,0 +1,33 @@
+package com.osori.lovesj.notification;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+import com.osori.lovesj.R;
+
+public final class BirthdayNotificationChannel {
+	public static final String CHANNEL_ID = "birthday_reminders";
+
+	private BirthdayNotificationChannel() {
+	}
+
+	public static void ensureCreated(Context context) {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+			return;
+		}
+
+		NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+		if (notificationManager == null || notificationManager.getNotificationChannel(CHANNEL_ID) != null) {
+			return;
+		}
+
+		NotificationChannel channel = new NotificationChannel(
+				CHANNEL_ID,
+				context.getString(R.string.notification_channel_name),
+				NotificationManager.IMPORTANCE_DEFAULT);
+		channel.setDescription(context.getString(R.string.notification_channel_description));
+		notificationManager.createNotificationChannel(channel);
+	}
+}

--- a/app/src/main/java/com/osori/lovesj/notification/BirthdayNotificationScheduler.java
+++ b/app/src/main/java/com/osori/lovesj/notification/BirthdayNotificationScheduler.java
@@ -1,0 +1,44 @@
+package com.osori.lovesj.notification;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.Calendar;
+
+public final class BirthdayNotificationScheduler {
+	private static final int REQUEST_CODE = 1001;
+
+	private BirthdayNotificationScheduler() {
+	}
+
+	public static void scheduleDaily(Context context) {
+		AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+		if (alarmManager == null) {
+			return;
+		}
+
+		PendingIntent pendingIntent = PendingIntent.getBroadcast(
+				context,
+				REQUEST_CODE,
+				new Intent(context, BirthdayAlarmReceiver.class),
+				PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+		Calendar calendar = Calendar.getInstance();
+		calendar.set(Calendar.HOUR_OF_DAY, 9);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+
+		if (calendar.getTimeInMillis() <= System.currentTimeMillis()) {
+			calendar.add(Calendar.DAY_OF_YEAR, 1);
+		}
+
+		alarmManager.setInexactRepeating(
+				AlarmManager.RTC_WAKEUP,
+				calendar.getTimeInMillis(),
+				AlarmManager.INTERVAL_DAY,
+				pendingIntent);
+	}
+}

--- a/app/src/main/java/com/osori/lovesj/notification/BirthdayNotifier.java
+++ b/app/src/main/java/com/osori/lovesj/notification/BirthdayNotifier.java
@@ -1,0 +1,95 @@
+package com.osori.lovesj.notification;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import com.osori.lovesj.R;
+import com.osori.lovesj.activity.OsoriActivity;
+import com.osori.lovesj.anniversary.BirthDay;
+import com.osori.lovesj.utils.BirthDayUtils;
+import com.osori.lovesj.utils.DayCounter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class BirthdayNotifier {
+	private static final int NOTIFICATION_ID = 2001;
+	private static final Set<Long> NOTIFY_DAYS_BEFORE = new HashSet<>();
+
+	static {
+		NOTIFY_DAYS_BEFORE.add(7L);
+		NOTIFY_DAYS_BEFORE.add(3L);
+		NOTIFY_DAYS_BEFORE.add(1L);
+		NOTIFY_DAYS_BEFORE.add(0L);
+	}
+
+	private BirthdayNotifier() {
+	}
+
+	public static void notifyUpcomingBirthdays(Context context) {
+		BirthdayNotificationChannel.ensureCreated(context);
+
+		List<String> upcoming = buildUpcomingMessages();
+		if (upcoming.isEmpty()) {
+			return;
+		}
+
+		String summary = buildSummary(context, upcoming);
+		String bigText = String.join("\n", upcoming);
+
+		PendingIntent contentIntent = PendingIntent.getActivity(
+				context,
+				0,
+				new Intent(context, OsoriActivity.class),
+				PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+		Notification notification = new Notification.Builder(context, BirthdayNotificationChannel.CHANNEL_ID)
+				.setSmallIcon(R.mipmap.ic_launcher)
+				.setContentTitle(context.getString(R.string.notification_birthday_title))
+				.setContentText(summary)
+				.setStyle(new Notification.BigTextStyle().bigText(bigText))
+				.setContentIntent(contentIntent)
+				.setAutoCancel(true)
+				.build();
+
+		NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		if (notificationManager != null) {
+			notificationManager.notify(NOTIFICATION_ID, notification);
+		}
+	}
+
+	private static List<String> buildUpcomingMessages() {
+		List<String> upcoming = new ArrayList<>();
+		LocalDate today = LocalDate.now();
+
+		for (BirthDay birthDay : BirthDay.values()) {
+			LocalDate upcomingDate = BirthDayUtils.findUpComingBirthDay(birthDay.getBirth(), birthDay.isLunarBirthDay());
+			long daysUntil = DayCounter.countDdayFrom(upcomingDate, today);
+			if (daysUntil < 0 || !NOTIFY_DAYS_BEFORE.contains(daysUntil)) {
+				continue;
+			}
+
+			if (daysUntil == 0) {
+				upcoming.add(birthDay.name() + " 생일이 오늘이에요!");
+			} else {
+				upcoming.add(birthDay.name() + " 생일이 " + daysUntil + "일 남았어요.");
+			}
+		}
+
+		return upcoming;
+	}
+
+	private static String buildSummary(Context context, List<String> upcoming) {
+		if (upcoming.size() == 1) {
+			return upcoming.get(0);
+		}
+
+		return context.getString(R.string.notification_birthday_summary, upcoming.size());
+	}
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
 	<string name="couple_name_kor">오소리들</string>
 	<string name="husband_family">기훈이네</string>
 	<string name="wife_family">수진이네</string>
+	<string name="notification_channel_name">생일 알림</string>
+	<string name="notification_channel_description">생일이 다가오면 알려드릴게요.</string>
+	<string name="notification_birthday_title">생일이 다가왔어요</string>
+	<string name="notification_birthday_summary">%1$d개의 생일이 가까워요.</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript {
-    repositories {
-        google()
-        jcenter()
-
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+plugins {
+    id 'com.android.application' version '8.5.2' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        jcenter()
-
-    }
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
+tasks.register('clean', Delete) {
+    delete rootProject.layout.buildDirectory
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'


### PR DESCRIPTION
### Motivation
- Provide multiple reminder notifications ahead of birthdays (7, 3, 1 days and on the day) rather than a single 7-day window.  
- Ensure reminders are delivered by a background daily check so users don't need to keep the app open.  
- Persist scheduling across device reboots and support Android 13+ runtime notification permission flow.

### Description
- Added `BirthdayNotificationChannel` to create a notification channel on Android O+ and added strings for channel name/description and notification texts.  
- Added `BirthdayNotificationScheduler` to schedule a daily `AlarmManager` trigger at 9:00, plus `BirthdayAlarmReceiver` to run notifications and `BirthdayBootReceiver` to re-schedule after reboot; registered receivers and permissions in `AndroidManifest.xml`.  
- Updated `OsoriActivity` to call `BirthdayNotificationChannel.ensureCreated(this)`, call `BirthdayNotificationScheduler.scheduleDaily(this)`, and request `POST_NOTIFICATIONS` permission on Android 13+ via `requestNotificationPermissionIfNeeded()`.  
- Modified `BirthdayNotifier` to use a `Set` of days `{7,3,1,0}` and only build/send notifications for birthdays matching those offsets.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69771630716c8328bd3d1e0d50bb637d)