### PR TITLE
Add birthday D-Day app widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,18 @@
 				<action android:name="android.intent.action.BOOT_COMPLETED"/>
 			</intent-filter>
 		</receiver>
+
+		<receiver
+				android:name=".widget.BirthdayWidgetProvider"
+				android:exported="false"
+				android:label="@string/widget_birthday_name">
+			<intent-filter>
+				<action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
+			</intent-filter>
+			<meta-data
+					android:name="android.appwidget.provider"
+					android:resource="@xml/birthday_widget_info"/>
+		</receiver>
 	</application>
 
 </manifest>

--- a/app/src/main/java/com/osori/lovesj/notification/BirthdayBootReceiver.java
+++ b/app/src/main/java/com/osori/lovesj/notification/BirthdayBootReceiver.java
@@ -4,11 +4,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.osori.lovesj.widget.BirthdayWidgetScheduler;
+
 public class BirthdayBootReceiver extends BroadcastReceiver {
 	@Override
 	public void onReceive(Context context, Intent intent) {
 		if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
 			BirthdayNotificationScheduler.scheduleDaily(context);
+			BirthdayWidgetScheduler.scheduleDaily(context);
 		}
 	}
 }

--- a/app/src/main/java/com/osori/lovesj/widget/BirthdayWidgetProvider.java
+++ b/app/src/main/java/com/osori/lovesj/widget/BirthdayWidgetProvider.java
@@ -1,0 +1,137 @@
+package com.osori.lovesj.widget;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.util.TypedValue;
+import android.widget.RemoteViews;
+
+import com.osori.lovesj.R;
+import com.osori.lovesj.anniversary.BirthDay;
+import com.osori.lovesj.utils.BirthDayUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BirthdayWidgetProvider extends AppWidgetProvider {
+	private static final String ACTION_NEXT = "com.osori.lovesj.widget.ACTION_NEXT";
+	private static final String ACTION_PREVIOUS = "com.osori.lovesj.widget.ACTION_PREVIOUS";
+	private static final String ACTION_DAILY_UPDATE = "com.osori.lovesj.widget.ACTION_DAILY_UPDATE";
+
+	private static final String EXTRA_INDEX = "com.osori.lovesj.widget.EXTRA_INDEX";
+
+	public static Intent buildUpdateIntent(Context context) {
+		Intent intent = new Intent(context, BirthdayWidgetProvider.class);
+		intent.setAction(ACTION_DAILY_UPDATE);
+		return intent;
+	}
+
+	@Override
+	public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+		for (int appWidgetId : appWidgetIds) {
+			updateWidget(context, appWidgetManager, appWidgetId, 0);
+		}
+		BirthdayWidgetScheduler.scheduleDaily(context);
+	}
+
+	@Override
+	public void onEnabled(Context context) {
+		BirthdayWidgetScheduler.scheduleDaily(context);
+	}
+
+	@Override
+	public void onDisabled(Context context) {
+		BirthdayWidgetScheduler.cancelDaily(context);
+	}
+
+	@Override
+	public void onReceive(Context context, Intent intent) {
+		super.onReceive(context, intent);
+		String action = intent.getAction();
+		if (action == null) {
+			return;
+		}
+
+		AppWidgetManager manager = AppWidgetManager.getInstance(context);
+		ComponentName componentName = new ComponentName(context, BirthdayWidgetProvider.class);
+		int[] widgetIds = manager.getAppWidgetIds(componentName);
+
+		switch (action) {
+			case ACTION_NEXT:
+			case ACTION_PREVIOUS:
+				int currentIndex = intent.getIntExtra(EXTRA_INDEX, 0);
+				for (int widgetId : widgetIds) {
+					updateWidget(context, manager, widgetId, currentIndex);
+				}
+				break;
+			case ACTION_DAILY_UPDATE:
+				for (int widgetId : widgetIds) {
+					updateWidget(context, manager, widgetId, 0);
+				}
+				break;
+			default:
+				break;
+		}
+	}
+
+	private void updateWidget(Context context, AppWidgetManager manager, int widgetId, int index) {
+		List<String> birthDayTexts = buildBirthDayTexts();
+		int currentIndex = normalizeIndex(index, birthDayTexts.size());
+
+		RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_birthday);
+		views.setTextViewText(R.id.widget_birthday_text_primary, getTextOrEmpty(birthDayTexts, currentIndex));
+		views.setTextViewText(R.id.widget_birthday_text_secondary,
+				getTextOrEmpty(birthDayTexts, currentIndex + 1));
+
+		int textSize = context.getResources().getDimensionPixelSize(R.dimen.widget_text_size);
+		views.setTextViewTextSize(R.id.widget_birthday_text_primary, TypedValue.COMPLEX_UNIT_PX, textSize);
+		views.setTextViewTextSize(R.id.widget_birthday_text_secondary, TypedValue.COMPLEX_UNIT_PX, textSize);
+
+		views.setOnClickPendingIntent(
+				R.id.widget_button_prev,
+				buildActionIntent(context, widgetId, ACTION_PREVIOUS, currentIndex - 1));
+		views.setOnClickPendingIntent(
+				R.id.widget_button_next,
+				buildActionIntent(context, widgetId, ACTION_NEXT, currentIndex + 1));
+
+		manager.updateAppWidget(widgetId, views);
+	}
+
+	private static PendingIntent buildActionIntent(Context context, int widgetId, String action, int index) {
+		Intent intent = new Intent(context, BirthdayWidgetProvider.class);
+		intent.setAction(action);
+		intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetId);
+		intent.putExtra(EXTRA_INDEX, index);
+		return PendingIntent.getBroadcast(
+				context,
+				widgetId + action.hashCode(),
+				intent,
+				PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+	}
+
+	private static int normalizeIndex(int index, int size) {
+		if (size <= 0) {
+			return 0;
+		}
+		int normalized = index % size;
+		return normalized < 0 ? normalized + size : normalized;
+	}
+
+	private static String getTextOrEmpty(List<String> texts, int index) {
+		if (texts.isEmpty()) {
+			return "";
+		}
+		return texts.get(normalizeIndex(index, texts.size()));
+	}
+
+	private static List<String> buildBirthDayTexts() {
+		List<String> result = new ArrayList<>();
+		for (BirthDay birthDay : BirthDay.values()) {
+			result.add(BirthDayUtils.buildBirthDayText(birthDay));
+		}
+		return result;
+	}
+}

--- a/app/src/main/java/com/osori/lovesj/widget/BirthdayWidgetScheduler.java
+++ b/app/src/main/java/com/osori/lovesj/widget/BirthdayWidgetScheduler.java
@@ -1,0 +1,58 @@
+package com.osori.lovesj.widget;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.Calendar;
+
+public final class BirthdayWidgetScheduler {
+	private static final int REQUEST_CODE = 2001;
+
+	private BirthdayWidgetScheduler() {
+	}
+
+	public static void scheduleDaily(Context context) {
+		AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+		if (alarmManager == null) {
+			return;
+		}
+
+		PendingIntent pendingIntent = PendingIntent.getBroadcast(
+				context,
+				REQUEST_CODE,
+				BirthdayWidgetProvider.buildUpdateIntent(context),
+				PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+		Calendar calendar = Calendar.getInstance();
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+
+		if (calendar.getTimeInMillis() <= System.currentTimeMillis()) {
+			calendar.add(Calendar.DAY_OF_YEAR, 1);
+		}
+
+		alarmManager.setInexactRepeating(
+				AlarmManager.RTC_WAKEUP,
+				calendar.getTimeInMillis(),
+				AlarmManager.INTERVAL_DAY,
+				pendingIntent);
+	}
+
+	public static void cancelDaily(Context context) {
+		AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+		if (alarmManager == null) {
+			return;
+		}
+
+		PendingIntent pendingIntent = PendingIntent.getBroadcast(
+				context,
+				REQUEST_CODE,
+				BirthdayWidgetProvider.buildUpdateIntent(context),
+				PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+		alarmManager.cancel(pendingIntent);
+	}
+}

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+	android:shape="rectangle">
+	<solid android:color="@color/white" />
+	<corners android:radius="16dp" />
+	<stroke
+		android:width="1dp"
+		android:color="@color/lightPink" />
+</shape>

--- a/app/src/main/res/layout/widget_birthday.xml
+++ b/app/src/main/res/layout/widget_birthday.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/widget_container"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:background="@drawable/widget_background"
+	android:gravity="center"
+	android:orientation="vertical"
+	android:padding="@dimen/widget_padding">
+
+	<TextView
+		android:id="@+id/widget_birthday_text_primary"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:ellipsize="end"
+		android:gravity="center"
+		android:maxLines="1"
+		android:textColor="@color/colorText"
+		android:textStyle="bold" />
+
+	<TextView
+		android:id="@+id/widget_birthday_text_secondary"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:ellipsize="end"
+		android:gravity="center"
+		android:layout_marginTop="@dimen/widget_spacing"
+		android:maxLines="1"
+		android:textColor="@color/colorText" />
+
+	<LinearLayout
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_marginTop="@dimen/widget_spacing"
+		android:gravity="center"
+		android:orientation="horizontal">
+
+		<TextView
+			android:id="@+id/widget_button_prev"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:paddingHorizontal="@dimen/widget_button_padding"
+			android:text="@string/widget_prev"
+			android:textColor="@color/colorText"
+			android:textStyle="bold" />
+
+		<TextView
+			android:id="@+id/widget_button_next"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="@dimen/widget_button_spacing"
+			android:paddingHorizontal="@dimen/widget_button_padding"
+			android:text="@string/widget_next"
+			android:textColor="@color/colorText"
+			android:textStyle="bold" />
+	</LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,4 +5,5 @@
 	<color name="colorAccent">#D81B60</color>
 	<color name="lightPink">#FFD9EC</color>
 	<color name="white">#FFFFFF</color>
+	<color name="colorText">#333333</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<dimen name="widget_padding">12dp</dimen>
+	<dimen name="widget_spacing">6dp</dimen>
+	<dimen name="widget_button_padding">8dp</dimen>
+	<dimen name="widget_button_spacing">12dp</dimen>
+	<dimen name="widget_text_size">14sp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,8 @@
 	<string name="notification_channel_description">생일이 다가오면 알려드릴게요.</string>
 	<string name="notification_birthday_title">생일이 다가왔어요</string>
 	<string name="notification_birthday_summary">%1$d개의 생일이 가까워요.</string>
+	<string name="widget_birthday_name">생일 D-Day 위젯</string>
+	<string name="widget_birthday_description">텍스트와 생일만 보여주는 D-Day 위젯</string>
+	<string name="widget_prev">◀</string>
+	<string name="widget_next">▶</string>
 </resources>

--- a/app/src/main/res/xml/birthday_widget_info.xml
+++ b/app/src/main/res/xml/birthday_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+	android:description="@string/widget_birthday_description"
+	android:initialLayout="@layout/widget_birthday"
+	android:minHeight="110dp"
+	android:minWidth="250dp"
+	android:resizeMode="horizontal|vertical"
+	android:updatePeriodMillis="0"
+	android:widgetCategory="home_screen" />


### PR DESCRIPTION
### Motivation
- Provide a lightweight home-screen widget that shows upcoming birthdays as D‑Day text lines without images.  
- Ensure the widget content updates once per day at midnight to keep D‑Day counts accurate.  
- Allow simple manual navigation between entries using previous/next taps on the widget.

### Description
- Add `BirthdayWidgetProvider` to render two text lines and handle `ACTION_NEXT`/`ACTION_PREVIOUS` and daily update intents, sourcing lines from `BirthDayUtils.buildBirthDayText()`; new file `app/src/main/java/com/osori/lovesj/widget/BirthdayWidgetProvider.java`.  
- Add `BirthdayWidgetScheduler` to schedule and cancel a daily midnight update using `AlarmManager` and `BirthdayWidgetProvider.buildUpdateIntent()`; new file `app/src/main/java/com/osori/lovesj/widget/BirthdayWidgetScheduler.java`.  
- Add widget layout and assets including `widget_birthday.xml`, `widget_background.xml`, `dimens.xml`, color/string resources and widget provider info `res/xml/birthday_widget_info.xml`.  
- Register the widget in `AndroidManifest.xml` and wire boot handling to schedule the widget updates by calling `BirthdayWidgetScheduler.scheduleDaily()` from `BirthdayBootReceiver`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772d1ef54483288549edaa7548e252)